### PR TITLE
Add FastAPI backend with authentication and job management

### DIFF
--- a/backend_new/alembic.ini
+++ b/backend_new/alembic.ini
@@ -1,0 +1,35 @@
+[alembic]
+script_location = migrations
+sqlalchemy.url = sqlite:///./app.db
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers = console
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers = console
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/backend_new/app/__init__.py
+++ b/backend_new/app/__init__.py
@@ -1,0 +1,3 @@
+from .main import app
+
+__all__ = ["app"]

--- a/backend_new/app/config.py
+++ b/backend_new/app/config.py
@@ -1,0 +1,26 @@
+from functools import lru_cache
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    APP_NAME: str = "Logistics Backend"
+    DATABASE_URL: str = "sqlite:///./app.db"
+    SECRET_KEY: str = "super-secret-development-key"
+    ALGORITHM: str = "HS256"
+    ACCESS_TOKEN_EXPIRE_MINUTES: int = 60
+
+    class Config:
+        env_file = ".env"
+        case_sensitive = True
+
+    @property
+    def sqlalchemy_database_uri(self) -> str:
+        return self.DATABASE_URL
+
+
+@lru_cache
+def get_settings() -> Settings:
+    return Settings()
+
+
+settings = get_settings()

--- a/backend_new/app/database.py
+++ b/backend_new/app/database.py
@@ -1,0 +1,27 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from .config import settings
+
+
+def _get_engine_url() -> str:
+    return settings.sqlalchemy_database_uri
+
+
+def _engine_kwargs() -> dict:
+    url = _get_engine_url()
+    if url.startswith("sqlite"):
+        return {"connect_args": {"check_same_thread": False}}
+    return {}
+
+
+engine = create_engine(_get_engine_url(), **_engine_kwargs())
+SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/backend_new/app/dependencies.py
+++ b/backend_new/app/dependencies.py
@@ -1,0 +1,51 @@
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer
+from sqlalchemy.orm import Session
+
+from .database import get_db
+from .models import Admin, Driver
+from .security import decode_token
+
+
+oauth2_scheme_admin = OAuth2PasswordBearer(tokenUrl="token")
+oauth2_scheme_driver = OAuth2PasswordBearer(tokenUrl="drivers/login")
+
+
+class Role(str):
+    ADMIN = "admin"
+    DRIVER = "driver"
+
+
+def _get_identity(token: str, expected_role: str, db: Session):
+    try:
+        payload = decode_token(token)
+    except ValueError as exc:  # pragma: no cover - handled by FastAPI
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token") from exc
+
+    if payload.get("role") != expected_role:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Insufficient permissions")
+
+    subject = payload.get("sub")
+    if subject is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+
+    if expected_role == Role.ADMIN:
+        user = db.query(Admin).filter(Admin.email == subject).first()
+    else:
+        user = db.query(Driver).filter(Driver.email == subject).first()
+
+    if not user:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found")
+
+    return user
+
+
+def get_current_admin(token: str = Depends(oauth2_scheme_admin), db: Session = Depends(get_db)):
+    return _get_identity(token, Role.ADMIN, db)
+
+
+def get_current_driver(token: str = Depends(oauth2_scheme_driver), db: Session = Depends(get_db)):
+    driver = _get_identity(token, Role.DRIVER, db)
+    if not driver.is_active:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Driver inactive")
+    return driver

--- a/backend_new/app/main.py
+++ b/backend_new/app/main.py
@@ -1,0 +1,23 @@
+from fastapi import FastAPI
+
+from .config import settings
+from .models import Base
+from .database import engine
+from .routers import auth, customers, drivers, health, invoices, credit_notes, jobs
+
+Base.metadata.create_all(bind=engine)
+
+app = FastAPI(title=settings.APP_NAME)
+
+app.include_router(health.router)
+app.include_router(auth.router)
+app.include_router(drivers.router)
+app.include_router(jobs.router)
+app.include_router(customers.router)
+app.include_router(invoices.router)
+app.include_router(credit_notes.router)
+
+
+@app.get("/")
+def read_root():
+    return {"message": "Welcome to the Logistics Backend"}

--- a/backend_new/app/models/__init__.py
+++ b/backend_new/app/models/__init__.py
@@ -1,0 +1,12 @@
+from .models import Base, Admin, Driver, Customer, Job, JobStatus, Invoice, CreditNote
+
+__all__ = [
+    "Base",
+    "Admin",
+    "Driver",
+    "Customer",
+    "Job",
+    "JobStatus",
+    "Invoice",
+    "CreditNote",
+]

--- a/backend_new/app/models/models.py
+++ b/backend_new/app/models/models.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+
+from sqlalchemy import Boolean, Column, DateTime, Enum as SqlEnum, Float, ForeignKey, Integer, String, Text
+from sqlalchemy.orm import declarative_base, relationship
+
+Base = declarative_base()
+
+
+class JobStatus(str, Enum):
+    PENDING = "pending"
+    ASSIGNED = "assigned"
+    IN_PROGRESS = "in_progress"
+    COMPLETED = "completed"
+    CANCELLED = "cancelled"
+
+
+class Admin(Base):
+    __tablename__ = "admins"
+
+    id = Column(Integer, primary_key=True, index=True)
+    email = Column(String, unique=True, nullable=False, index=True)
+    full_name = Column(String, nullable=False)
+    hashed_password = Column(String, nullable=False)
+
+
+class Driver(Base):
+    __tablename__ = "drivers"
+
+    id = Column(Integer, primary_key=True, index=True)
+    email = Column(String, unique=True, nullable=False, index=True)
+    full_name = Column(String, nullable=False)
+    phone = Column(String, nullable=True)
+    hashed_password = Column(String, nullable=False)
+    is_active = Column(Boolean, default=True, nullable=False)
+
+    jobs = relationship("Job", back_populates="driver")
+
+
+class Customer(Base):
+    __tablename__ = "customers"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, nullable=False)
+    email = Column(String, unique=True, nullable=False, index=True)
+    address = Column(Text, nullable=True)
+    phone = Column(String, nullable=True)
+
+    jobs = relationship("Job", back_populates="customer")
+    invoices = relationship("Invoice", back_populates="customer")
+    credit_notes = relationship("CreditNote", back_populates="customer")
+
+
+class Job(Base):
+    __tablename__ = "jobs"
+
+    id = Column(Integer, primary_key=True, index=True)
+    title = Column(String, nullable=False)
+    description = Column(Text, nullable=True)
+    status = Column(SqlEnum(JobStatus), default=JobStatus.PENDING, nullable=False)
+    scheduled_at = Column(DateTime, nullable=True)
+    completed_at = Column(DateTime, nullable=True)
+    driver_id = Column(Integer, ForeignKey("drivers.id"), nullable=True)
+    customer_id = Column(Integer, ForeignKey("customers.id"), nullable=False)
+
+    driver = relationship("Driver", back_populates="jobs")
+    customer = relationship("Customer", back_populates="jobs")
+    invoice = relationship("Invoice", back_populates="job", uselist=False)
+    credit_notes = relationship("CreditNote", back_populates="job")
+
+
+class Invoice(Base):
+    __tablename__ = "invoices"
+
+    id = Column(Integer, primary_key=True, index=True)
+    job_id = Column(Integer, ForeignKey("jobs.id"), unique=True, nullable=False)
+    customer_id = Column(Integer, ForeignKey("customers.id"), nullable=False)
+    amount = Column(Float, nullable=False)
+    status = Column(String, default="draft", nullable=False)
+    issued_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+    job = relationship("Job", back_populates="invoice")
+    customer = relationship("Customer", back_populates="invoices")
+
+
+class CreditNote(Base):
+    __tablename__ = "credit_notes"
+
+    id = Column(Integer, primary_key=True, index=True)
+    job_id = Column(Integer, ForeignKey("jobs.id"), nullable=False)
+    customer_id = Column(Integer, ForeignKey("customers.id"), nullable=False)
+    amount = Column(Float, nullable=False)
+    reason = Column(Text, nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+    job = relationship("Job", back_populates="credit_notes")
+    customer = relationship("Customer", back_populates="credit_notes")

--- a/backend_new/app/routers/__init__.py
+++ b/backend_new/app/routers/__init__.py
@@ -1,0 +1,11 @@
+from . import auth, customers, drivers, health, invoices, credit_notes, jobs
+
+__all__ = [
+    "auth",
+    "customers",
+    "drivers",
+    "health",
+    "invoices",
+    "credit_notes",
+    "jobs",
+]

--- a/backend_new/app/routers/auth.py
+++ b/backend_new/app/routers/auth.py
@@ -1,0 +1,42 @@
+from datetime import timedelta
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordRequestForm
+from sqlalchemy.orm import Session
+
+from ..config import settings
+from ..database import get_db
+from ..dependencies import Role
+from ..models import Admin, Driver
+from ..schemas.auth import AdminToken, DriverToken
+from ..security import create_access_token, verify_password
+
+router = APIRouter(tags=["auth"])
+
+
+@router.post("/token", response_model=AdminToken, summary="Admin login")
+def login_for_access_token(
+    form_data: OAuth2PasswordRequestForm = Depends(), db: Session = Depends(get_db)
+):
+    admin = db.query(Admin).filter(Admin.email == form_data.username).first()
+    if not admin or not verify_password(form_data.password, admin.hashed_password):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Incorrect credentials")
+
+    access_token_expires = timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
+    access_token = create_access_token(admin.email, Role.ADMIN, access_token_expires)
+    return AdminToken(access_token=access_token)
+
+
+@router.post("/drivers/login", response_model=DriverToken, summary="Driver login")
+def driver_login(
+    form_data: OAuth2PasswordRequestForm = Depends(), db: Session = Depends(get_db)
+):
+    driver = db.query(Driver).filter(Driver.email == form_data.username).first()
+    if not driver or not verify_password(form_data.password, driver.hashed_password):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Incorrect credentials")
+    if not driver.is_active:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Driver inactive")
+
+    access_token_expires = timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
+    access_token = create_access_token(driver.email, Role.DRIVER, access_token_expires)
+    return DriverToken(access_token=access_token)

--- a/backend_new/app/routers/credit_notes.py
+++ b/backend_new/app/routers/credit_notes.py
@@ -1,0 +1,73 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from ..database import get_db
+from ..dependencies import get_current_admin
+from ..models import CreditNote
+from ..schemas.credit_note import CreditNoteCreate, CreditNoteRead, CreditNoteUpdate
+
+router = APIRouter(prefix="/credit-notes", tags=["credit-notes"])
+
+
+@router.get("", response_model=list[CreditNoteRead])
+def list_credit_notes(db: Session = Depends(get_db), admin=Depends(get_current_admin)):
+    return db.query(CreditNote).all()
+
+
+@router.post("", response_model=CreditNoteRead, status_code=status.HTTP_201_CREATED)
+def create_credit_note(
+    credit_note_in: CreditNoteCreate,
+    db: Session = Depends(get_db),
+    admin=Depends(get_current_admin),
+):
+    credit_note = CreditNote(**credit_note_in.model_dump())
+    db.add(credit_note)
+    db.commit()
+    db.refresh(credit_note)
+    return credit_note
+
+
+@router.get("/{credit_note_id}", response_model=CreditNoteRead)
+def read_credit_note(
+    credit_note_id: int,
+    db: Session = Depends(get_db),
+    admin=Depends(get_current_admin),
+):
+    credit_note = db.get(CreditNote, credit_note_id)
+    if not credit_note:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Credit note not found")
+    return credit_note
+
+
+@router.put("/{credit_note_id}", response_model=CreditNoteRead)
+def update_credit_note(
+    credit_note_id: int,
+    credit_note_in: CreditNoteUpdate,
+    db: Session = Depends(get_db),
+    admin=Depends(get_current_admin),
+):
+    credit_note = db.get(CreditNote, credit_note_id)
+    if not credit_note:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Credit note not found")
+
+    for field, value in credit_note_in.model_dump(exclude_unset=True).items():
+        setattr(credit_note, field, value)
+
+    db.add(credit_note)
+    db.commit()
+    db.refresh(credit_note)
+    return credit_note
+
+
+@router.delete("/{credit_note_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_credit_note(
+    credit_note_id: int,
+    db: Session = Depends(get_db),
+    admin=Depends(get_current_admin),
+):
+    credit_note = db.get(CreditNote, credit_note_id)
+    if not credit_note:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Credit note not found")
+    db.delete(credit_note)
+    db.commit()
+    return None

--- a/backend_new/app/routers/customers.py
+++ b/backend_new/app/routers/customers.py
@@ -1,0 +1,63 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from ..database import get_db
+from ..dependencies import get_current_admin
+from ..models import Customer
+from ..schemas.customer import CustomerCreate, CustomerRead, CustomerUpdate
+
+router = APIRouter(prefix="/customers", tags=["customers"])
+
+
+@router.get("", response_model=list[CustomerRead])
+def list_customers(db: Session = Depends(get_db), admin=Depends(get_current_admin)):
+    return db.query(Customer).all()
+
+
+@router.post("", response_model=CustomerRead, status_code=status.HTTP_201_CREATED)
+def create_customer(customer_in: CustomerCreate, db: Session = Depends(get_db), admin=Depends(get_current_admin)):
+    if db.query(Customer).filter(Customer.email == customer_in.email).first():
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Customer already exists")
+    customer = Customer(**customer_in.model_dump())
+    db.add(customer)
+    db.commit()
+    db.refresh(customer)
+    return customer
+
+
+@router.get("/{customer_id}", response_model=CustomerRead)
+def read_customer(customer_id: int, db: Session = Depends(get_db), admin=Depends(get_current_admin)):
+    customer = db.get(Customer, customer_id)
+    if not customer:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Customer not found")
+    return customer
+
+
+@router.put("/{customer_id}", response_model=CustomerRead)
+def update_customer(
+    customer_id: int,
+    customer_in: CustomerUpdate,
+    db: Session = Depends(get_db),
+    admin=Depends(get_current_admin),
+):
+    customer = db.get(Customer, customer_id)
+    if not customer:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Customer not found")
+
+    for field, value in customer_in.model_dump(exclude_unset=True).items():
+        setattr(customer, field, value)
+
+    db.add(customer)
+    db.commit()
+    db.refresh(customer)
+    return customer
+
+
+@router.delete("/{customer_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_customer(customer_id: int, db: Session = Depends(get_db), admin=Depends(get_current_admin)):
+    customer = db.get(Customer, customer_id)
+    if not customer:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Customer not found")
+    db.delete(customer)
+    db.commit()
+    return None

--- a/backend_new/app/routers/drivers.py
+++ b/backend_new/app/routers/drivers.py
@@ -1,0 +1,96 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from ..database import get_db
+from ..dependencies import get_current_admin, get_current_driver
+from ..models import Driver, Job
+from ..schemas.driver import DriverCreate, DriverJobSummary, DriverRead, DriverUpdate
+from ..security import get_password_hash
+
+router = APIRouter(prefix="/drivers", tags=["drivers"])
+
+
+@router.post("", response_model=DriverRead, status_code=status.HTTP_201_CREATED)
+def create_driver(
+    driver_in: DriverCreate, db: Session = Depends(get_db), admin=Depends(get_current_admin)
+):
+    if db.query(Driver).filter(Driver.email == driver_in.email).first():
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Driver already exists")
+    driver = Driver(
+        email=driver_in.email,
+        full_name=driver_in.full_name,
+        phone=driver_in.phone,
+        is_active=driver_in.is_active,
+        hashed_password=get_password_hash(driver_in.password),
+    )
+    db.add(driver)
+    db.commit()
+    db.refresh(driver)
+    return driver
+
+
+@router.get("", response_model=list[DriverRead])
+def list_drivers(db: Session = Depends(get_db), admin=Depends(get_current_admin)):
+    return db.query(Driver).all()
+
+
+@router.get("/me", response_model=DriverRead)
+def read_current_driver(driver=Depends(get_current_driver)):
+    return driver
+
+
+@router.get("/me/jobs", response_model=list[DriverJobSummary])
+def read_current_driver_jobs(
+    db: Session = Depends(get_db), driver=Depends(get_current_driver)
+):
+    jobs = (
+        db.query(Job)
+        .filter(Job.driver_id == driver.id)
+        .order_by(Job.scheduled_at.is_(None), Job.scheduled_at)
+        .all()
+    )
+    return jobs
+
+
+@router.get("/{driver_id}", response_model=DriverRead)
+def read_driver(driver_id: int, db: Session = Depends(get_db), admin=Depends(get_current_admin)):
+    driver = db.get(Driver, driver_id)
+    if not driver:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Driver not found")
+    return driver
+
+
+@router.put("/{driver_id}", response_model=DriverRead)
+def update_driver(
+    driver_id: int,
+    driver_in: DriverUpdate,
+    db: Session = Depends(get_db),
+    admin=Depends(get_current_admin),
+):
+    driver = db.get(Driver, driver_id)
+    if not driver:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Driver not found")
+
+    if driver_in.full_name is not None:
+        driver.full_name = driver_in.full_name
+    if driver_in.phone is not None:
+        driver.phone = driver_in.phone
+    if driver_in.is_active is not None:
+        driver.is_active = driver_in.is_active
+    if driver_in.password:
+        driver.hashed_password = get_password_hash(driver_in.password)
+
+    db.add(driver)
+    db.commit()
+    db.refresh(driver)
+    return driver
+
+
+@router.delete("/{driver_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_driver(driver_id: int, db: Session = Depends(get_db), admin=Depends(get_current_admin)):
+    driver = db.get(Driver, driver_id)
+    if not driver:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Driver not found")
+    db.delete(driver)
+    db.commit()
+    return None

--- a/backend_new/app/routers/health.py
+++ b/backend_new/app/routers/health.py
@@ -1,0 +1,8 @@
+from fastapi import APIRouter
+
+router = APIRouter(tags=["health"])
+
+
+@router.get("/health", summary="Service health check")
+def health_check():
+    return {"status": "ok"}

--- a/backend_new/app/routers/invoices.py
+++ b/backend_new/app/routers/invoices.py
@@ -1,0 +1,65 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from ..database import get_db
+from ..dependencies import get_current_admin
+from ..models import Invoice
+from ..schemas.invoice import InvoiceCreate, InvoiceRead, InvoiceUpdate
+
+router = APIRouter(prefix="/invoices", tags=["invoices"])
+
+
+@router.get("", response_model=list[InvoiceRead])
+def list_invoices(db: Session = Depends(get_db), admin=Depends(get_current_admin)):
+    return db.query(Invoice).all()
+
+
+@router.post("", response_model=InvoiceRead, status_code=status.HTTP_201_CREATED)
+def create_invoice(
+    invoice_in: InvoiceCreate, db: Session = Depends(get_db), admin=Depends(get_current_admin)
+):
+    if db.query(Invoice).filter(Invoice.job_id == invoice_in.job_id).first():
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invoice already exists for job")
+    invoice = Invoice(**invoice_in.model_dump())
+    db.add(invoice)
+    db.commit()
+    db.refresh(invoice)
+    return invoice
+
+
+@router.get("/{invoice_id}", response_model=InvoiceRead)
+def read_invoice(invoice_id: int, db: Session = Depends(get_db), admin=Depends(get_current_admin)):
+    invoice = db.get(Invoice, invoice_id)
+    if not invoice:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Invoice not found")
+    return invoice
+
+
+@router.put("/{invoice_id}", response_model=InvoiceRead)
+def update_invoice(
+    invoice_id: int,
+    invoice_in: InvoiceUpdate,
+    db: Session = Depends(get_db),
+    admin=Depends(get_current_admin),
+):
+    invoice = db.get(Invoice, invoice_id)
+    if not invoice:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Invoice not found")
+
+    for field, value in invoice_in.model_dump(exclude_unset=True).items():
+        setattr(invoice, field, value)
+
+    db.add(invoice)
+    db.commit()
+    db.refresh(invoice)
+    return invoice
+
+
+@router.delete("/{invoice_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_invoice(invoice_id: int, db: Session = Depends(get_db), admin=Depends(get_current_admin)):
+    invoice = db.get(Invoice, invoice_id)
+    if not invoice:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Invoice not found")
+    db.delete(invoice)
+    db.commit()
+    return None

--- a/backend_new/app/routers/jobs.py
+++ b/backend_new/app/routers/jobs.py
@@ -1,0 +1,125 @@
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from ..database import get_db
+from ..dependencies import get_current_admin, get_current_driver
+from ..models import Job, JobStatus
+from ..schemas.job import JobCreate, JobRead, JobUpdate
+
+router = APIRouter(prefix="/jobs", tags=["jobs"])
+
+
+@router.get("", response_model=list[JobRead])
+def list_jobs(db: Session = Depends(get_db), admin=Depends(get_current_admin)):
+    return db.query(Job).all()
+
+
+@router.post("", response_model=JobRead, status_code=status.HTTP_201_CREATED)
+def create_job(job_in: JobCreate, db: Session = Depends(get_db), admin=Depends(get_current_admin)):
+    try:
+        status_value = JobStatus(job_in.status) if job_in.status else JobStatus.PENDING
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid job status") from exc
+
+    job = Job(
+        title=job_in.title,
+        description=job_in.description,
+        status=status_value,
+        driver_id=job_in.driver_id,
+        customer_id=job_in.customer_id,
+        scheduled_at=job_in.scheduled_at,
+        completed_at=job_in.completed_at,
+    )
+    db.add(job)
+    db.commit()
+    db.refresh(job)
+    return job
+
+
+@router.get("/{job_id}", response_model=JobRead)
+def read_job(job_id: int, db: Session = Depends(get_db), admin=Depends(get_current_admin)):
+    job = db.get(Job, job_id)
+    if not job:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Job not found")
+    return job
+
+
+@router.put("/{job_id}", response_model=JobRead)
+def update_job(
+    job_id: int,
+    job_in: JobUpdate,
+    db: Session = Depends(get_db),
+    admin=Depends(get_current_admin),
+):
+    job = db.get(Job, job_id)
+    if not job:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Job not found")
+
+    if job_in.title is not None:
+        job.title = job_in.title
+    if job_in.description is not None:
+        job.description = job_in.description
+    if job_in.status is not None:
+        try:
+            job.status = JobStatus(job_in.status)
+        except ValueError as exc:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid job status") from exc
+    if job_in.driver_id is not None:
+        job.driver_id = job_in.driver_id
+    if job_in.customer_id is not None:
+        job.customer_id = job_in.customer_id
+    if job_in.scheduled_at is not None:
+        job.scheduled_at = job_in.scheduled_at
+    if job_in.completed_at is not None:
+        job.completed_at = job_in.completed_at
+
+    db.add(job)
+    db.commit()
+    db.refresh(job)
+    return job
+
+
+@router.delete("/{job_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_job(job_id: int, db: Session = Depends(get_db), admin=Depends(get_current_admin)):
+    job = db.get(Job, job_id)
+    if not job:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Job not found")
+    db.delete(job)
+    db.commit()
+    return None
+
+
+@router.post("/{job_id}/{action}", response_model=JobRead)
+def perform_action_on_job(
+    job_id: int,
+    action: str,
+    db: Session = Depends(get_db),
+    current_driver=Depends(get_current_driver),
+):
+    job = db.get(Job, job_id)
+    if not job:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Job not found")
+    if job.driver_id != current_driver.id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Job not assigned to driver")
+
+    normalized_action = action.lower()
+    if normalized_action == "start":
+        job.status = JobStatus.IN_PROGRESS
+        job.scheduled_at = job.scheduled_at or datetime.utcnow()
+    elif normalized_action == "complete":
+        job.status = JobStatus.COMPLETED
+        job.completed_at = datetime.utcnow()
+    elif normalized_action == "cancel":
+        job.status = JobStatus.CANCELLED
+        job.completed_at = datetime.utcnow()
+    elif normalized_action == "acknowledge":
+        job.status = JobStatus.ASSIGNED
+    else:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Unsupported action")
+
+    db.add(job)
+    db.commit()
+    db.refresh(job)
+    return job

--- a/backend_new/app/schemas/auth.py
+++ b/backend_new/app/schemas/auth.py
@@ -1,0 +1,36 @@
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict
+
+
+class Token(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
+
+
+class TokenPayload(BaseModel):
+    sub: str
+    role: str
+    exp: datetime
+
+
+class LoginRequest(BaseModel):
+    username: str
+    password: str
+
+
+class DriverToken(Token):
+    expires_at: Optional[datetime] = None
+
+
+class AdminToken(Token):
+    expires_at: Optional[datetime] = None
+
+
+class UserIdentity(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    email: str
+    full_name: str

--- a/backend_new/app/schemas/credit_note.py
+++ b/backend_new/app/schemas/credit_note.py
@@ -1,0 +1,30 @@
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict
+
+
+class CreditNoteBase(BaseModel):
+    job_id: int
+    customer_id: int
+    amount: float
+    reason: Optional[str] = None
+    created_at: Optional[datetime] = None
+
+
+class CreditNoteCreate(CreditNoteBase):
+    pass
+
+
+class CreditNoteUpdate(BaseModel):
+    job_id: Optional[int] = None
+    customer_id: Optional[int] = None
+    amount: Optional[float] = None
+    reason: Optional[str] = None
+    created_at: Optional[datetime] = None
+
+
+class CreditNoteRead(CreditNoteBase):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int

--- a/backend_new/app/schemas/customer.py
+++ b/backend_new/app/schemas/customer.py
@@ -1,0 +1,27 @@
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict
+
+
+class CustomerBase(BaseModel):
+    name: str
+    email: str
+    address: Optional[str] = None
+    phone: Optional[str] = None
+
+
+class CustomerCreate(CustomerBase):
+    pass
+
+
+class CustomerUpdate(BaseModel):
+    name: Optional[str] = None
+    email: Optional[str] = None
+    address: Optional[str] = None
+    phone: Optional[str] = None
+
+
+class CustomerRead(CustomerBase):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int

--- a/backend_new/app/schemas/driver.py
+++ b/backend_new/app/schemas/driver.py
@@ -1,0 +1,44 @@
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict
+
+from .job import JobRead
+
+
+class DriverBase(BaseModel):
+    full_name: str
+    email: str
+    phone: Optional[str] = None
+    is_active: bool = True
+
+
+class DriverCreate(DriverBase):
+    password: str
+
+
+class DriverUpdate(BaseModel):
+    full_name: Optional[str] = None
+    phone: Optional[str] = None
+    is_active: Optional[bool] = None
+    password: Optional[str] = None
+
+
+class DriverRead(DriverBase):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+
+
+class DriverWithJobs(DriverRead):
+    jobs: list[JobRead] = []
+
+
+class DriverJobSummary(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    title: str
+    status: str
+    scheduled_at: Optional[datetime] = None
+    completed_at: Optional[datetime] = None

--- a/backend_new/app/schemas/invoice.py
+++ b/backend_new/app/schemas/invoice.py
@@ -1,0 +1,30 @@
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict
+
+
+class InvoiceBase(BaseModel):
+    job_id: int
+    customer_id: int
+    amount: float
+    status: Optional[str] = "draft"
+    issued_at: Optional[datetime] = None
+
+
+class InvoiceCreate(InvoiceBase):
+    pass
+
+
+class InvoiceUpdate(BaseModel):
+    job_id: Optional[int] = None
+    customer_id: Optional[int] = None
+    amount: Optional[float] = None
+    status: Optional[str] = None
+    issued_at: Optional[datetime] = None
+
+
+class InvoiceRead(InvoiceBase):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int

--- a/backend_new/app/schemas/job.py
+++ b/backend_new/app/schemas/job.py
@@ -1,0 +1,34 @@
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict
+
+
+class JobBase(BaseModel):
+    title: str
+    description: Optional[str] = None
+    status: Optional[str] = None
+    driver_id: Optional[int] = None
+    customer_id: int
+    scheduled_at: Optional[datetime] = None
+    completed_at: Optional[datetime] = None
+
+
+class JobCreate(JobBase):
+    status: Optional[str] = None
+
+
+class JobUpdate(BaseModel):
+    title: Optional[str] = None
+    description: Optional[str] = None
+    status: Optional[str] = None
+    driver_id: Optional[int] = None
+    customer_id: Optional[int] = None
+    scheduled_at: Optional[datetime] = None
+    completed_at: Optional[datetime] = None
+
+
+class JobRead(JobBase):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int

--- a/backend_new/app/security.py
+++ b/backend_new/app/security.py
@@ -1,0 +1,37 @@
+from datetime import datetime, timedelta
+from typing import Optional
+
+from jose import JWTError, jwt
+from passlib.context import CryptContext
+
+from .config import settings
+
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    return pwd_context.verify(plain_password, hashed_password)
+
+
+def get_password_hash(password: str) -> str:
+    return pwd_context.hash(password)
+
+
+def create_access_token(subject: str, role: str, expires_delta: Optional[timedelta] = None) -> str:
+    if expires_delta is None:
+        expires_delta = timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
+    to_encode = {
+        "sub": subject,
+        "role": role,
+        "exp": datetime.utcnow() + expires_delta,
+    }
+    return jwt.encode(to_encode, settings.SECRET_KEY, algorithm=settings.ALGORITHM)
+
+
+def decode_token(token: str) -> dict:
+    try:
+        payload = jwt.decode(token, settings.SECRET_KEY, algorithms=[settings.ALGORITHM])
+        return payload
+    except JWTError as exc:  # pragma: no cover - simple pass-through
+        raise ValueError("Invalid token") from exc

--- a/backend_new/migrations/README
+++ b/backend_new/migrations/README
@@ -1,0 +1,1 @@
+This directory contains Alembic database migrations.

--- a/backend_new/migrations/env.py
+++ b/backend_new/migrations/env.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import pathlib
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+
+BASE_DIR = pathlib.Path(__file__).resolve().parents[1]
+if str(BASE_DIR) not in __import__("sys").path:
+    __import__("sys").path.insert(0, str(BASE_DIR))
+
+from app.config import settings  # noqa: E402
+from app.models import Base  # noqa: E402
+
+config = context.config
+config.set_main_option("sqlalchemy.url", settings.sqlalchemy_database_uri)
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = Base.metadata
+
+
+def run_migrations_offline() -> None:
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(url=url, target_metadata=target_metadata, literal_binds=True)
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/backend_new/migrations/script.py.mako
+++ b/backend_new/migrations/script.py.mako
@@ -1,0 +1,17 @@
+"""${message}"""
+
+revision = ${repr(revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/backend_new/migrations/versions/202403031200_initial.py
+++ b/backend_new/migrations/versions/202403031200_initial.py
@@ -1,0 +1,90 @@
+"""initial schema"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "202403031200"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+job_status = sa.Enum(
+    "pending",
+    "assigned",
+    "in_progress",
+    "completed",
+    "cancelled",
+    name="jobstatus",
+)
+
+
+def upgrade() -> None:
+    op.create_table(
+        "admins",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("email", sa.String(), nullable=False, unique=True),
+        sa.Column("full_name", sa.String(), nullable=False),
+        sa.Column("hashed_password", sa.String(), nullable=False),
+    )
+
+    op.create_table(
+        "drivers",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("email", sa.String(), nullable=False, unique=True),
+        sa.Column("full_name", sa.String(), nullable=False),
+        sa.Column("phone", sa.String(), nullable=True),
+        sa.Column("hashed_password", sa.String(), nullable=False),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.text("1")),
+    )
+
+    op.create_table(
+        "customers",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("email", sa.String(), nullable=False, unique=True),
+        sa.Column("address", sa.Text(), nullable=True),
+        sa.Column("phone", sa.String(), nullable=True),
+    )
+
+    op.create_table(
+        "jobs",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("title", sa.String(), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("status", job_status, nullable=False, server_default=sa.text("'pending'")),
+        sa.Column("scheduled_at", sa.DateTime(), nullable=True),
+        sa.Column("completed_at", sa.DateTime(), nullable=True),
+        sa.Column("driver_id", sa.Integer(), sa.ForeignKey("drivers.id"), nullable=True),
+        sa.Column("customer_id", sa.Integer(), sa.ForeignKey("customers.id"), nullable=False),
+    )
+
+    op.create_table(
+        "invoices",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("job_id", sa.Integer(), sa.ForeignKey("jobs.id"), nullable=False, unique=True),
+        sa.Column("customer_id", sa.Integer(), sa.ForeignKey("customers.id"), nullable=False),
+        sa.Column("amount", sa.Float(), nullable=False),
+        sa.Column("status", sa.String(), nullable=False, server_default=sa.text("'draft'")),
+        sa.Column("issued_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+    )
+
+    op.create_table(
+        "credit_notes",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("job_id", sa.Integer(), sa.ForeignKey("jobs.id"), nullable=False),
+        sa.Column("customer_id", sa.Integer(), sa.ForeignKey("customers.id"), nullable=False),
+        sa.Column("amount", sa.Float(), nullable=False),
+        sa.Column("reason", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("credit_notes")
+    op.drop_table("invoices")
+    op.drop_table("jobs")
+    op.drop_table("customers")
+    op.drop_table("drivers")
+    op.drop_table("admins")
+    job_status.drop(op.get_bind(), checkfirst=False)

--- a/backend_new/requirements.txt
+++ b/backend_new/requirements.txt
@@ -1,0 +1,9 @@
+fastapi==0.110.0
+uvicorn[standard]==0.27.1
+SQLAlchemy==2.0.25
+alembic==1.13.1
+pydantic==2.6.3
+pydantic-settings==2.2.1
+python-multipart==0.0.9
+passlib[bcrypt]==1.7.4
+python-jose[cryptography]==3.3.0

--- a/backend_new/seed.py
+++ b/backend_new/seed.py
@@ -1,0 +1,131 @@
+from datetime import datetime, timedelta
+
+from app.database import SessionLocal
+from app.models import Admin, CreditNote, Customer, Driver, Invoice, Job, JobStatus
+from app.security import get_password_hash
+
+
+ADMIN_EMAIL = "admin@example.com"
+DRIVER_EMAILS = ["driver1@example.com", "driver2@example.com"]
+CUSTOMER_EMAILS = ["acme@example.com", "globex@example.com"]
+
+
+def seed():
+    session = SessionLocal()
+
+    if session.query(Admin).filter(Admin.email == ADMIN_EMAIL).first():
+        print("Seed data already exists.")
+        session.close()
+        return
+
+    admin = Admin(
+        email=ADMIN_EMAIL,
+        full_name="System Admin",
+        hashed_password=get_password_hash("admin123"),
+    )
+
+    drivers = [
+        Driver(
+            email=DRIVER_EMAILS[0],
+            full_name="Alex Johnson",
+            phone="555-0101",
+            hashed_password=get_password_hash("driver123"),
+        ),
+        Driver(
+            email=DRIVER_EMAILS[1],
+            full_name="Jamie Smith",
+            phone="555-0102",
+            hashed_password=get_password_hash("driver456"),
+        ),
+    ]
+
+    customers = [
+        Customer(
+            name="ACME Corp",
+            email=CUSTOMER_EMAILS[0],
+            address="123 Industrial Way",
+            phone="555-0201",
+        ),
+        Customer(
+            name="Globex LLC",
+            email=CUSTOMER_EMAILS[1],
+            address="456 Enterprise Rd",
+            phone="555-0202",
+        ),
+    ]
+
+    session.add(admin)
+    session.add_all(drivers + customers)
+    session.commit()
+
+    session.refresh(drivers[0])
+    session.refresh(drivers[1])
+    session.refresh(customers[0])
+    session.refresh(customers[1])
+
+    jobs = [
+        Job(
+            title="Warehouse Pickup",
+            description="Pick up goods from ACME warehouse",
+            status=JobStatus.ASSIGNED,
+            scheduled_at=datetime.utcnow() + timedelta(days=1),
+            driver_id=drivers[0].id,
+            customer_id=customers[0].id,
+        ),
+        Job(
+            title="City Delivery",
+            description="Deliver goods to downtown",
+            status=JobStatus.IN_PROGRESS,
+            scheduled_at=datetime.utcnow(),
+            driver_id=drivers[0].id,
+            customer_id=customers[0].id,
+        ),
+        Job(
+            title="Long Haul",
+            description="Transport equipment to Globex",
+            status=JobStatus.PENDING,
+            scheduled_at=datetime.utcnow() + timedelta(days=3),
+            driver_id=drivers[1].id,
+            customer_id=customers[1].id,
+        ),
+        Job(
+            title="Return Shipment",
+            description="Return unused materials",
+            status=JobStatus.COMPLETED,
+            scheduled_at=datetime.utcnow() - timedelta(days=2),
+            completed_at=datetime.utcnow() - timedelta(days=1),
+            driver_id=drivers[1].id,
+            customer_id=customers[1].id,
+        ),
+    ]
+
+    session.add_all(jobs)
+    session.commit()
+
+    session.refresh(jobs[0])
+    session.refresh(jobs[1])
+
+    invoice = Invoice(
+        job_id=jobs[0].id,
+        customer_id=customers[0].id,
+        amount=350.0,
+        status="issued",
+        issued_at=datetime.utcnow(),
+    )
+
+    credit_note = CreditNote(
+        job_id=jobs[1].id,
+        customer_id=customers[0].id,
+        amount=50.0,
+        reason="Damaged items",
+        created_at=datetime.utcnow(),
+    )
+
+    session.add_all([invoice, credit_note])
+    session.commit()
+    session.close()
+    print("Seed data created.")
+
+
+if __name__ == "__main__":
+    seed()


### PR DESCRIPTION
## Summary
- add a new FastAPI backend project configured with SQLAlchemy, JWT auth, and resource routers for drivers, jobs, customers, invoices, and credit notes
- scaffold Alembic with an initial migration for all core entities and configuration ready for SQLite and PostgreSQL
- provide a seeding script to populate an admin, drivers, customers, jobs, and initial billing records

## Testing
- python -m compileall backend_new/app

------
https://chatgpt.com/codex/tasks/task_e_68dea43606788331a343849d244b48af